### PR TITLE
Fix maven jar plugin configuration for deploying test jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -873,6 +873,33 @@
                         </gpgArguments>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>2.2</version>
+                    <executions>
+                        <execution>
+                            <id>default-test</id>
+                            <configuration>
+                                <includes>
+                                    <include>**/ignite/cache/redis/*</include>
+                                    <include>**/ignite/dao/utils/*</include>
+                                    <include>**/redis/embedded/*</include>
+                                    <include>**/analytics/stream/base/utils/EmbeddedMQTTServer.class</include>
+                                    <include>**/analytics/stream/base/kafka/EmbeddedKafka.class</include>
+                                    <include>**/analytics/stream/base/kafka/EmbeddedZookeeper.class</include>
+                                    <include>**/analytics/stream/base/kafka/SingleNodeKafkaCluster.class</include>
+                                    <include>**/analytics/stream/base/utils/KafkaStreamsApplicationTestBase.class</include>
+                                    <include>**/analytics/stream/base/utils/KafkaStreamsApplicationTestBase$*.class
+                                    </include>
+                                </includes>
+                            </configuration>
+                            <goals>
+                                <goal>test-jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -1071,29 +1098,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.2</version>
-                <executions>
-                    <execution>
-                        <id>default-test</id>
-                        <configuration>
-                            <includes>
-                                <include>**/ignite/cache/redis/*</include>
-                                <include>**/ignite/dao/utils/*</include>
-                                <include>**/redis/embedded/*</include>
-                                <include>**/analytics/stream/base/utils/EmbeddedMQTTServer.class</include>
-                                <include>**/analytics/stream/base/kafka/EmbeddedKafka.class</include>
-                                <include>**/analytics/stream/base/kafka/EmbeddedZookeeper.class</include>
-                                <include>**/analytics/stream/base/kafka/SingleNodeKafkaCluster.class</include>
-                                <include>**/analytics/stream/base/utils/KafkaStreamsApplicationTestBase.class</include>
-                                <include>**/analytics/stream/base/utils/KafkaStreamsApplicationTestBase$*.class
-                                </include>
-                            </includes>
-                        </configuration>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>
@@ -1125,7 +1129,7 @@
         <profile>
             <id>release</id>
 			<properties>
-                <maven.test.skip>true</maven.test.skip>
+                <maven.test.skip>false</maven.test.skip>
             </properties>
 			<distributionManagement>
                 <snapshotRepository>
@@ -1163,6 +1167,10 @@
 							</execution>
 						</executions>
 					</plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                    </plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-source-plugin</artifactId>


### PR DESCRIPTION
Resolves #25 

----
### Describe behaviour before the change
* Test JAR for streambase was not being deployed. Streambase needs to deploy a test JAR, which contains base test classes for starting embedded Kafka and Redis, and also for publishing and receiving messages from the embedded Kafka. This is used by other components which are integrating streambase to write integration test suites.



### Describe behaviour after the change
* Test JAR will be deployed now when release streambase library.

### Pull request checklist
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All new and existing tests passed.
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
- [ ] Yes
- [x] No

----

