### PR TITLE
Fix clients not being removed from map during shutdown of application

### DIFF
--- a/src/main/java/org/eclipse/ecsp/analytics/stream/base/utils/HiveMqMqttDispatcher.java
+++ b/src/main/java/org/eclipse/ecsp/analytics/stream/base/utils/HiveMqMqttDispatcher.java
@@ -321,6 +321,7 @@ public class HiveMqMqttDispatcher extends MqttDispatcher {
                         client.getConfig().getClientIdentifier());
                 client = null;
             }
+            mqttClientMap.remove(platform);
         }
     }
 

--- a/src/main/java/org/eclipse/ecsp/analytics/stream/base/utils/PahoMqttDispatcher.java
+++ b/src/main/java/org/eclipse/ecsp/analytics/stream/base/utils/PahoMqttDispatcher.java
@@ -345,7 +345,7 @@ public class PahoMqttDispatcher extends MqttDispatcher {
                         + "Resetting reference to null.", mqttClientId, platform);
                 client = null;
             }
-            mqttClientMap.put(platform, null);
+            mqttClientMap.remove(platform);
         }
     }
 


### PR DESCRIPTION
Resolves #28 

----
### Describe behaviour before the change
* Exception when attempting to add null value in a ConcurrentHashMap

### Describe behaviour after the change
* Entry is removed from map, instead of adding null value during clean of mqtt client map

### Pull request checklist
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All new and existing tests passed.
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
- [ ] Yes
- [x] No

----

