### PR TITLE
Ignite transformer added for serialization during metrics collection

### DIFF
--- a/src/main/java/org/eclipse/ecsp/analytics/stream/base/processors/ProtocolTranslatorPreProcessor.java
+++ b/src/main/java/org/eclipse/ecsp/analytics/stream/base/processors/ProtocolTranslatorPreProcessor.java
@@ -689,7 +689,7 @@ public class ProtocolTranslatorPreProcessor implements StreamProcessor<byte[], b
      * @param igniteEvent the ignite event
      */
     private void collectDataConsumptionMetric(IgniteKey<?> igniteKey, IgniteEvent igniteEvent) {
-        Transformer trans = transformerMap.get(transformerSource);
+        Transformer trans = transformerMap.get(IgniteEventSource.IGNITE);
         // handle composite-event
         if (igniteEvent.getNestedEvents() != null && !igniteEvent.getNestedEvents().isEmpty()) {
             for (IgniteEvent event : igniteEvent.getNestedEvents()) {


### PR DESCRIPTION
Resolves #32 

----
### Describe behaviour before the change
* If data consumption metrics, or prometheus is enabled, Streambase serializes the IgniteEvent to byte[], and calculates size of the array for metrics. For this, custom protobuf transformer's toBlob() method is getting called, and resulting in error during serialization as the protobuf transformer is not supposed to do any serialization in V2C events.

### Describe behaviour after the change
* GenericIgniteEventTransformer will be used for serialization during data metrics collection.

### Pull request checklist
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All new and existing tests passed.
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
- [x] Yes
- [ ] No

This can be a breaking change for services which are not using the intended GenericIgniteEventTransformer for serialization when pushing events from api component to Kafka for C2V events.
----

