### PR TITLE
Add harman package to component scan as a workaround

### DIFF
--- a/src/main/java/org/eclipse/ecsp/analytics/stream/base/Launcher.java
+++ b/src/main/java/org/eclipse/ecsp/analytics/stream/base/Launcher.java
@@ -76,7 +76,8 @@ import static org.eclipse.ecsp.analytics.stream.base.utils.Constants.COLON_9100;
  */
 @Configuration
 @ComponentScan(basePackages = { "org.eclipse.ecsp", "com.harman" }, excludeFilters
-        = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = "org.eclipse.ecsp.hashicorp.*") })
+        = {@ComponentScan.Filter(type = FilterType.REGEX,
+        pattern = "org.eclipse.ecsp.hashicorp.*|com.harman.hashicorp.*") })
 @PropertySource("classpath:/application-base.properties")
 @PropertySource(ignoreResourceNotFound = true, value = "classpath:/application.properties")
 @PropertySource(ignoreResourceNotFound = true, value = "classpath:/application-ext.properties")

--- a/src/main/java/org/eclipse/ecsp/analytics/stream/base/Launcher.java
+++ b/src/main/java/org/eclipse/ecsp/analytics/stream/base/Launcher.java
@@ -75,7 +75,7 @@ import static org.eclipse.ecsp.analytics.stream.base.utils.Constants.COLON_9100;
  * @author ssasidharan
  */
 @Configuration
-@ComponentScan(basePackages = { "org.eclipse.ecsp" }, excludeFilters
+@ComponentScan(basePackages = { "org.eclipse.ecsp", "com.harman" }, excludeFilters
         = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = "org.eclipse.ecsp.hashicorp.*") })
 @PropertySource("classpath:/application-base.properties")
 @PropertySource(ignoreResourceNotFound = true, value = "classpath:/application.properties")


### PR DESCRIPTION
Workaround for #35 

----
### Describe behaviour before the change
* Integrating services are not able to provide spring configuration class

### Describe behaviour after the change
* Added com.harman package in the package scan when launching the application. This PR contains a workaround for this defect, and a fix will be released in 1.2.0.

### Pull request checklist
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All new and existing tests passed.
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
- [ ] Yes
- [x] No

----

