### PR TITLE
Fix NPE when processing connection status event with ECU

### DIFF
--- a/src/main/java/org/eclipse/ecsp/stream/dma/handler/DeviceConnectionStatusHandler.java
+++ b/src/main/java/org/eclipse/ecsp/stream/dma/handler/DeviceConnectionStatusHandler.java
@@ -253,7 +253,7 @@ public class DeviceConnectionStatusHandler implements DeviceMessageHandler {
      * @param ecuTypes the new up ecu types
      */
     private static void setupEcuTypes(List<String> ecuTypes) {
-        DeviceConnectionStatusHandler.ecuTypes = ecuTypes;
+        DeviceConnectionStatusHandler.ecuTypes = (ecuTypes != null) ? ecuTypes : new ArrayList<>();
     }
 
     /**


### PR DESCRIPTION
Resolves #37

----
### Describe behaviour before the change
* Stream base throwing error while processing subscribe/unsubscribe events from the device without the property dma.dispatcher.ecu.types

### Describe behaviour after the change
* ECU type list has been initialized with an empty list, in case no ecus are defined in configuration to avoid NPE.

### Pull request checklist
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All new and existing tests passed.
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
- [ ] Yes
- [x] No

----

