### PR TITLE
Issue #40 KafkaStreams state management optimizations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.ecsp</groupId>
     <artifactId>streambase</artifactId>
-    <version>1.2-defect-730039-SNAPSHOT</version>
+    <version>1.2-defect-730039-2-SNAPSHOT</version>
 
     <name>StreamBase library</name>
     <description>Enabler for event driven processing and device messaging capabilities</description>

--- a/src/main/java/org/eclipse/ecsp/analytics/stream/base/KafkaStateListener.java
+++ b/src/main/java/org/eclipse/ecsp/analytics/stream/base/KafkaStateListener.java
@@ -137,7 +137,7 @@ public class KafkaStateListener implements KafkaStreams.StateListener, HealthMon
         streamsThreadStateCounter = Counter.build()
                 .name(KAFKA_STREAMS_THREAD_STATE_COUNTER)
                 .help("Kafka Streams Thread State")
-                .labelNames("service_name", "thread_name", "state", "last_updated_timestamp")
+                .labelNames("service_name", "thread_name", "old_state", "new_state", "last_updated_timestamp")
                 .register();
         logger.info("Initialized Prometheus gauge for Kafka Streams thread state.");
     }
@@ -169,37 +169,36 @@ public class KafkaStateListener implements KafkaStreams.StateListener, HealthMon
      */
     @Override
     public void onChange(State newState, State oldState) {
+        logger.info("Stream state changed from {} to {}", oldState, newState);
+        String streamsThreadName = Thread.currentThread().getName();
         if (State.RUNNING == newState) {
             healthy = true;
+            publishStateMetrics(newState, oldState, streamsThreadName);
         } else {
             healthy = false;
-        }
-        logger.info("Stream state changed from {} to {}", oldState, newState);
-        if (State.REBALANCING == newState || State.ERROR == newState || State.NOT_RUNNING == newState) {
-            String streamsThreadName = Thread.currentThread().getName();
             logger.error("Streams thread: {} is in {} state!", streamsThreadName, newState.toString());
-            
-            if (prometheusEnabled) {
-                switch (newState) {
-                    case REBALANCING:
-                        streamsThreadStateCounter.labels(serviceName, streamsThreadName, 
-                                State.REBALANCING.toString(), System.currentTimeMillis() + "")
-                                .inc();
-                        break;
-                    case ERROR:
-                        streamsThreadStateCounter.labels(serviceName, streamsThreadName, 
-                                State.ERROR.toString(), System.currentTimeMillis() + "")
-                                .inc();
-                        break;
-                    case NOT_RUNNING:
-                        streamsThreadStateCounter.labels(serviceName, streamsThreadName, 
-                                State.NOT_RUNNING.toString(), System.currentTimeMillis() + "")
-                                .inc();
-                        break;
-                    default:
-                        logger.error("Unknown Kafka Streams state!");
-                }        
-            }
+            switch (newState) {
+                case CREATED: 
+                    publishStateMetrics(newState, oldState, streamsThreadName);
+                    break;
+                case REBALANCING:
+                    publishStateMetrics(newState, oldState, streamsThreadName);
+                    break;
+                case PENDING_SHUTDOWN:
+                    publishStateMetrics(newState, oldState, streamsThreadName);
+                    break;
+                case PENDING_ERROR:
+                    publishStateMetrics(newState, oldState, streamsThreadName);
+                    break;
+                case ERROR:
+                    publishStateMetrics(newState, oldState, streamsThreadName);
+                    break;
+                case NOT_RUNNING:
+                    publishStateMetrics(newState, oldState, streamsThreadName);
+                    break;
+                default:
+                    logger.error("Unknown Kafka Streams state!");
+            }        
         }
         if (State.REBALANCING == oldState && State.RUNNING == newState) {
             Map<String, KafkaStateAgentListener> kafkaAgentListeners = applicationContext
@@ -207,6 +206,26 @@ public class KafkaStateListener implements KafkaStreams.StateListener, HealthMon
 
             kafkaAgentListeners.values().forEach(listner -> listner.onChange(newState, oldState));
             offsetManager.setUp();
+        }
+    }
+    
+    /**
+     * Publishes the {@link KafkaStreams} thread state metrics to Prometheus.
+     *
+     * @param newState
+     *            the new state of the Kafka Streams thread.
+     * @param oldState
+     *            the old state of the Kafka Streams thread.
+     * @param threadName
+     *            the name of the Kafka Streams thread.
+     */
+    private void publishStateMetrics(State newState, State oldState, String threadName) {
+        if (prometheusEnabled) {
+            streamsThreadStateCounter.labels(serviceName, threadName, oldState.toString(), 
+                    newState.toString(), System.currentTimeMillis() + "")
+                    .inc();
+            logger.info("Published state metrics for Kafka Streams thread: {} with state: {}", 
+                    threadName, newState);
         }
     }
 


### PR DESCRIPTION
Please refer to our [contributing docs](./CONTRIBUTING.md) for any questions on submitting a pull request.
Issues are required for both bug fixes and features.

Resolves #40 
<!-- Link to related issue(s) -->

----
### Describe behaviour before the change
Following is the existing logic of KafkaStreams state management in streambase:

If a streaming thread is in REBALANCING state a flag is set to true to keep a track that it is not in RUNNING state. This flag is flipped when the streaming thread again transits back to RUNNING state from REBALANCING.
A Java thread is spawned off which is put to sleep for ~10mins and when this thread wakes up, it checks the value of the flag, if the value of the flag is still "true", which means, the streaming thread is still in NON RUNNING state (according to this spawned off thread, it might not actually be true), then the action to exit the container (restart the streaming application) is taken by this spawned off thread which introduces a downtime until the container is back up again.
A behavior of BackdoorKafkaConsumer was that it was relying on the state of KafkaStreams thread to decide whether it should shutdown or not which is an incorrect behavior as backdoor kafka consumer is independent of KafkaStreams.
 

### Describe behaviour after the change
1. Logic to monitor the state of streams thread and to take the decision of restarting the application has been removed as we don't want to induce downtime unnecessarily now that KafkaStreams itself is matured and capable enough to handle the NON RUNNING state of streams thread.
2. Instead of restarting the application, a Counter metric will be published to Prometheus server with the following labels: "service_name", "thread_name", "state", "last_updated_timestamp" . This will allow to debug that which thread went into what state, how many times it went into that state and when was the last time it went into that state.
3. BackdoorKafkaConsumer will now shutdown and restart only and only if exception is encountered by the backdoor kafka consumer, irrespective of what the state of KafkaStreams is.

* 

### Pull request checklist
- [ ] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] All new and existing tests passed.
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [ ] No

----

