### PR TITLE
Bugfix/46 bug add support for backward compatibility with fst serializers

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -118,9 +118,9 @@ maven/mavencentral/org.aspectj/aspectjweaver/1.9.22.1, EPL-1.0, approved, tools.
 maven/mavencentral/org.bitbucket.b_c/jose4j/0.9.4, Apache-2.0, approved, #4707
 maven/mavencentral/org.checkerframework/checker-qual/3.42.0, MIT, approved, #20003
 maven/mavencentral/org.eclipse.ecsp/cache-enabler/1.0.0, Apache-2.0, approved, automotive.ecsp
-maven/mavencentral/org.eclipse.ecsp/entities/1.1.1, Apache-2.0, approved, automotive.ecsp
+maven/mavencentral/org.eclipse.ecsp/entities/1.1.2, Apache-2.0, approved, automotive.ecsp
 maven/mavencentral/org.eclipse.ecsp/nosql-dao/1.1.1, Apache-2.0, approved, automotive.ecsp
-maven/mavencentral/org.eclipse.ecsp/transformers/1.0.0, Apache-2.0, approved, automotive.ecsp
+maven/mavencentral/org.eclipse.ecsp/transformers/1.0.1, Apache-2.0, approved, automotive.ecsp
 maven/mavencentral/org.eclipse.ecsp/utils/1.1.1, Apache-2.0, approved, automotive.ecsp
 maven/mavencentral/org.eclipse.paho/org.eclipse.paho.client.mqttv3/1.2.2, EPL-1.0 OR BSD-3-Clause, approved, iot.paho
 maven/mavencentral/org.glassfish.web/javax.el/2.2.6, CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #1654

--- a/pom.xml
+++ b/pom.xml
@@ -105,9 +105,9 @@
         <junit4.version>4.13.2</junit4.version>
         <nosql.dao.version>1.1.1</nosql.dao.version>
         <cache.enabler.version>1.0.0</cache.enabler.version>
-        <transformers.version>1.0.0</transformers.version>
+        <transformers.version>1.0.1</transformers.version>
         <utils.version>1.1.1</utils.version>
-        <entities.version>1.1.1</entities.version>
+        <entities.version>1.1.2</entities.version>
         <scala.version>2.13.14</scala.version>
         <curator.version>5.3.0</curator.version>
         <redis.jar.version>2.6.0.5</redis.jar.version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.ecsp</groupId>
     <artifactId>streambase</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>1.2-bug-49-SNAPSHOT</version>
 
     <name>StreamBase library</name>
     <description>Enabler for event driven processing and device messaging capabilities</description>


### PR DESCRIPTION
Please refer to our [contributing docs](./CONTRIBUTING.md) for any questions on submitting a pull request.
Issues are required for both bug fixes and features.

Resolves #46 

----
### Describe behaviour before the change
* Update version of transformers and entities which provide backward compatibility with FST serializers using legacy packages

### Describe behaviour after the change
* Streambase will now be able to deserialize using FST for V2C events with both legacy, and new packages.

### Pull request checklist
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All new and existing tests passed.
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
- [ ] Yes
- [x] No

----

