### PR TITLE
Issue #52 Apply null pointer check for ecuType property's presence in the DeviceMessage event.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.ecsp</groupId>
     <artifactId>streambase</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>1.2-739171-SNAPSHOT</version>
 
     <name>StreamBase library</name>
     <description>Enabler for event driven processing and device messaging capabilities</description>

--- a/src/main/java/org/eclipse/ecsp/stream/dma/handler/DispatchHandler.java
+++ b/src/main/java/org/eclipse/ecsp/stream/dma/handler/DispatchHandler.java
@@ -119,7 +119,8 @@ public class DispatchHandler implements DeviceMessageHandler {
      */
     @Override
     public void handle(IgniteKey<?> key, DeviceMessage value) {
-        if (brokerToEcuTypesMapping != null && brokerToEcuTypesMapping.size() > 0) {
+        if (brokerToEcuTypesMapping != null && brokerToEcuTypesMapping.size() > 0 
+                && value.getEvent().getEcuType() != null) {
             for (Map.Entry<String, Map<String, String>> entry : brokerToEcuTypesMapping.entrySet()) {
                 String broker = entry.getKey();
                 Map<String, String> ecuTypeToTopicMapping = entry.getValue();


### PR DESCRIPTION
Please refer to our [contributing docs](./CONTRIBUTING.md) for any questions on submitting a pull request.
Issues are required for both bug fixes and features.

Resolves #52 

----
### Describe behaviour before the change
The Device Messaging module in streambase library is designed to dispatch the events to either HiveMQ MQTT broker (the default one in streambase) or Kafka (configurable for the services). The decision that where to dispatch is taken if:

1. The following property is configured: dma_dispatcher_ecu_types AND
2. The incoming event contains the valid ecuType property

The bug arises when the property is configured but the event doesn't contain the ecuType property, which is a valid scenario as a service may want certain events to be dispatched to the default MQTT broker (legacy behavior of DMA) and certain events to be dispatched to Kafka broker.

* 

### Describe behaviour after the change
The NullPointerException is resolved.

* 

### Pull request checklist
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All new and existing tests passed.
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [x] No

----

