### PR TITLE
Bugfix/66 bug kryo library version 5 backward compatibility issue

### DIFF
--- a/src/main/java/org/eclipse/ecsp/analytics/stream/base/stores/ObjectStateStore.java
+++ b/src/main/java/org/eclipse/ecsp/analytics/stream/base/stores/ObjectStateStore.java
@@ -69,6 +69,7 @@ public class ObjectStateStore extends HarmanPersistentKVStore<String, Object> {
         Kryo k = new Kryo();
         k.setDefaultSerializer(CompatibleFieldSerializer.class);
         k.register(DateTime.class, new JodaDateTimeSerializer());
+        k.setRegistrationRequired(false);
         k.setCopyReferences(false);
         return k;
     });


### PR DESCRIPTION
Please refer to our [contributing docs](./CONTRIBUTING.md) for any questions on submitting a pull request.
Issues are required for both bug fixes and features.

Resolves #66 

----
### Describe behaviour before the change
* Kryo library was upgraded to v5 from v4 and type registration is enabled by default in Kryo framework v5 due to which services embedding streambase library and using state-store failed to initialize the state-store because the Java type was not registered with Kryo. It was disabled by default in Kryo v4. Currently, streambase library doesn't fully support the type registration with Kryo which is why this fix has been made.

### Describe behaviour after the change
* Explicitly disabled the type registration with Kryo in streambase to address the backward compatibility issue.

### Pull request checklist
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All new and existing tests passed.
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
- [ ] Yes
- [x] No

----

