### PR TITLE
fix eventTs value in dmOfflineBuffer

### DIFF
--- a/src/main/java/org/eclipse/ecsp/analytics/stream/base/utils/Constants.java
+++ b/src/main/java/org/eclipse/ecsp/analytics/stream/base/utils/Constants.java
@@ -174,6 +174,9 @@ public class Constants {
     
     /** The Constant THREAD_SLEEP_TIME_1000. */
     public static final int THREAD_SLEEP_TIME_1000 = 1000;
+
+    /** The Constant INT_1000. */
+    public static final int INT_1000 = 1000;
     
     /** The Constant INT_1883. */
     public static final int INT_1883 = 1883;

--- a/src/main/java/org/eclipse/ecsp/stream/dma/dao/DMOfflineBufferEntryDAOMongoImpl.java
+++ b/src/main/java/org/eclipse/ecsp/stream/dma/dao/DMOfflineBufferEntryDAOMongoImpl.java
@@ -41,6 +41,7 @@ package org.eclipse.ecsp.stream.dma.dao;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.ecsp.analytics.stream.base.PropertyNames;
+import org.eclipse.ecsp.analytics.stream.base.utils.Constants;
 import org.eclipse.ecsp.entities.dma.DeviceMessage;
 import org.eclipse.ecsp.entities.dma.DeviceMessageHeader;
 import org.eclipse.ecsp.key.IgniteKey;
@@ -112,7 +113,8 @@ public class DMOfflineBufferEntryDAOMongoImpl extends IgniteBaseDAOMongoImpl<Str
             DeviceMessage entity, String subService) {
         logger.debug("Add buffer entry for vehicle id {} and service {}", vehicleId, serviceNameIdentifier);
         DeviceMessageHeader header = entity.getDeviceMessageHeader();
-        LocalDateTime eventDate = LocalDateTime.ofEpochSecond(header.getTimestamp(), 0, ZoneOffset.UTC);
+        LocalDateTime eventDate = LocalDateTime.ofEpochSecond(
+            header.getTimestamp() / Constants.INT_1000, 0, ZoneOffset.UTC);
         DMOfflineBufferEntry offlineEntry = new DMOfflineBufferEntry();
         offlineEntry.setIgniteKey(igniteKey);
         offlineEntry.setVehicleId(vehicleId);

--- a/src/test/java/org/eclipse/ecsp/stream/dma/DMOfflineBufferIntegrationTest.java
+++ b/src/test/java/org/eclipse/ecsp/stream/dma/DMOfflineBufferIntegrationTest.java
@@ -200,6 +200,44 @@ public class DMOfflineBufferIntegrationTest extends KafkaStreamsApplicationTestB
     }
     
     /**
+     * Test event timestamp saved in correct format.
+     *
+     * @throws ExecutionException the execution exception
+     * @throws InterruptedException the interrupted exception
+     * @throws TimeoutException the timeout exception
+     */
+    @Test
+    public void testEventTimestampSavedInCorrectFormat() 
+           throws ExecutionException, InterruptedException, TimeoutException {
+        Properties producerProps = new Properties();
+        producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+        producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA_CLUSTER.bootstrapServers());
+        String deviceInactive = "{\"EventID\": \"DeviceConnStatus\",\"Version\": \"1.0\",\"Data\": "
+                + "{\"connStatus\":\"INACTIVE\",\"serviceName\":\"eCall\"},\"MessageId\": \"1234\",\"VehicleId\": "
+                + "\"Vehicle12345\",\"SourceDeviceId\": \"12345\"}";
+        sendMessages(deviceStatusTopicName, producerProps,
+                Arrays.asList(vehicleId.getBytes(), deviceInactive.getBytes()));
+        Thread.sleep(TestConstants.THREAD_SLEEP_TIME_5000);
+        assertNull(deviceService.get(vehicleId, Optional.empty()));
+        long currentTimeMillis = System.currentTimeMillis();
+        String speedEvent = "{\"EventID\": \"Speed\",\"Version\": \"1.0\",\"Data\": {\"value\":20.0},"
+                + "\"MessageId\": \"1234\",\"CorrelationId\": \"1234\",\"BizTransactionId\": \"Biz1234\","
+                + "\"VehicleId\": \"Vehicle12345\",\"SourceDeviceId\": \"12345\",\"Timestamp\": " 
+                + currentTimeMillis + "}";
+        sendMessages(sourceTopic, producerProps,
+                Arrays.asList(vehicleId.getBytes(), speedEvent.getBytes()));
+        Thread.sleep(TestConstants.THREAD_SLEEP_TIME_10000);
+        List<DMOfflineBufferEntry> bufferEntries = offlineBufferDAO.getOfflineBufferEntriesSortedByPriority(vehicleId, 
+                false, Optional.empty(), Optional.empty());
+        assertEquals("Expected one entry", 1, bufferEntries.size());
+        DMOfflineBufferEntry savedEntry = bufferEntries.get(0);
+        int currentYear = java.time.Year.now().getValue();
+        assertEquals("Event timestamp year should be current year", 
+                currentYear, savedEntry.getEventTs().getYear());
+    }
+    
+    /**
      * Tear down.
      */
     @After


### PR DESCRIPTION
Resolves #78 

----
### Describe behaviour before the change
* Year information in eventTs was being saved as invalid value ~54333

### Describe behaviour after the change
* EventTs is now being saved with the correct year value.

### Pull request checklist
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All new and existing tests passed.
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
- [ ] Yes
- [x] No

----

